### PR TITLE
Fix package init and project config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "requests",
     "python-dotenv",
 ]
-dependencies = ["requests"]
 
 [project.urls]
 Homepage = "https://github.com/habitualdev/goSynapse"

--- a/src/gosynapse/__init__.py
+++ b/src/gosynapse/__init__.py
@@ -8,13 +8,9 @@ try:
     SynapseClient = _SynapseClient
 except ModuleNotFoundError:  # requests may be missing in some environments
     SynapseClient = object()
+
 from .parse import parse_json_stream, InitData, Node, FiniData  # noqa: E402
 from .types import (  # noqa: E402
-from .client import SynapseClient
-from .parse import parse_json_stream, InitData, Node, FiniData
-from .types import (
-
-  main
     Users,
     Roles,
     Active,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# Ensure the package under src/ is importable when running tests directly
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SRC_PATH = os.path.join(PROJECT_ROOT, 'src')
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)


### PR DESCRIPTION
## Summary
- fix invalid imports in `gosynapse/__init__.py`
- clean up duplicated `dependencies` table in `pyproject.toml`
- ensure package is importable in tests

## Testing
- `pytest -q`
- `python3 -m compileall src/gosynapse`

------
https://chatgpt.com/codex/tasks/task_e_6840cf9c8dfc8327a3bd05b05867360d